### PR TITLE
Added Magento_ThemeGraphQl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "magento/module-eav-graph-ql": "*",
     "magento/module-graph-ql": "*",
     "magento/module-grouped-product-graph-ql": "*",
+    "magento/module-theme-graph-ql": "*",
     "magento/module-quote-graph-ql": "*",
     "magento/module-sales-graph-ql": "*",
     "magento/module-send-friend-graph-ql": "*",


### PR DESCRIPTION
Shouldn't be a problem to remove this module in case the whole graphQL stuff is not available.