### PR TITLE
Removed 2.3.3 graphql modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,12 @@
     "magento/module-url-rewrite-graph-ql": "*",
     "magento/module-vault-graph-ql": "*",
     "magento/module-weee-graph-ql": "*",
-    "magento/module-wishlist-graph-ql": "*"
+    "magento/module-wishlist-graph-ql": "*",
+    "magento/module-authorizenet-graph-ql": "*",
+    "magento/module-braintree-graph-ql": "*",
+    "magento/module-checkout-agreements-graph-ql": "*",
+    "magento/module-inventory-graph-ql": "*",
+    "magento/module-paypal-graph-ql": "*",
+    "magento/module-related-product-graph-ql": "*"
   }
 }


### PR DESCRIPTION
Removed more graphql modules

"magento/module-authorizenet-graph-ql": "*",
"magento/module-braintree-graph-ql": "*",
"magento/module-checkout-agreements-graph-ql": "*",
"magento/module-inventory-graph-ql": "*",
"magento/module-paypal-graph-ql": "*",
"magento/module-related-product-graph-ql": "*"

I did not test this thoroughly. di:compile seems to be working though