### PR TITLE
Added missing replace of module-catalog-rule-graph-ql module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "magento/module-catalog-customer-ql": "*",
     "magento/module-catalog-customer-graph-ql":"*",
     "magento/module-catalog-inventory-graph-ql": "*",
+    "magento/module-catalog-rule-graph-ql": "*",
     "magento/module-catalog-url-rewrite-graph-ql": "*",
     "magento/module-checkout-agreements-graph-ql":"*",
     "magento/module-cms-graph-ql": "*",


### PR DESCRIPTION
`magento/module-catalog-rule-graph-ql` module has been added since Magento 2.3.6, and should be replaced by the package.