### PR TITLE
Add magento/module-elasticsearch-catalog-permissions-graph-ql

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "magento/module-directory-graph-ql": "*",
     "magento/module-downloadable-graph-ql": "*",
     "magento/module-eav-graph-ql": "*",
+    "magento/module-elasticsearch-catalog-permissions-graph-ql": "*",
     "magento/module-gift-card-account-graph-ql": "*",
     "magento/module-gift-card-graph-ql": "*",
     "magento/module-gift-message-graph-ql": "*",


### PR DESCRIPTION
This module requires `magento/module-graph-ql`, which we want to replace